### PR TITLE
Feat/templated values

### DIFF
--- a/include/cart_queue.hpp
+++ b/include/cart_queue.hpp
@@ -16,8 +16,9 @@
  *
  * The cart queue is designed to be accessed by multiple consumers and producers concurrently.
  */
+template <typename value_t>
 struct cart_queue {
-    using cart = std::vector<std::string>;
+    using cart = std::vector<value_t>;
 
     // same as cart, but with additional mutex
     struct secured_cart {
@@ -51,7 +52,7 @@ struct cart_queue {
     }
 
     // Insert a query into a bin - thread safe
-    void insert(size_t bin_id, std::string query) {
+    void insert(size_t bin_id, value_t value) {
         assert(carts_being_filled.size() < bin_id && "bin_id has to be between 0 and number_of_bins");
 
         auto& cart = carts_being_filled[bin_id];
@@ -59,7 +60,7 @@ struct cart_queue {
         // locking the cart and inserting the query
         auto _ = std::lock_guard{cart.mutex};
         assert(cart.basket.size() < cart_max_capacity && "carts should always have at least one empty value");
-        cart.basket.emplace_back(std::move(query));
+        cart.basket.emplace_back(std::move(value));
 
         // check if cart is full
         if (cart.basket.size() == cart_max_capacity) {
@@ -110,7 +111,7 @@ struct cart_queue {
     }
 };
 
-void print_queue_carts(std::vector<cart_queue::secured_cart> const& cart_queue)
+void print_queue_carts(std::vector<cart_queue<std::string>::secured_cart> const& cart_queue)
 {
     std::cout << "\t\t\tCARTS\n";
     std::cout << "Bin ID\tQueries\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ int main(int /*argc*/, char const* const* /*argv*/)
     print_thread_result(valik_thread_result);
     // carts should be (bin, [reads])
 
-    cart_queue queue{nr_bins, cart_capacity, max_carts_queued};
+    auto queue = cart_queue<std::string>{nr_bins, cart_capacity, max_carts_queued};
 
     auto threads = std::vector<std::jthread>{};
 


### PR DESCRIPTION
Making the elements transported in a cart a template argument. This should allow us to use also stuff like `std::tuple<sequence_name, sequence>`